### PR TITLE
[DONT MERGE] Provide python actions access to key/value datastore

### DIFF
--- a/st2actions/st2actions/runners/python_action_wrapper.py
+++ b/st2actions/st2actions/runners/python_action_wrapper.py
@@ -16,19 +16,225 @@
 import sys
 import json
 import argparse
+import logging as stdlib_logging
 
 from st2common import log as logging
 from st2actions import config
 from st2actions.runners.pythonrunner import Action
+from st2client.client import Client
+from st2client.models import KeyValuePair
 from st2common.util import loader as action_loader
 from st2common.util.config_parser import ContentPackConfigParser
 from st2common.constants.action import ACTION_OUTPUT_RESULT_DELIMITER
+from st2common.service_setup import db_setup
+from st2common.services.access import create_token
+from st2common.util.api import get_full_public_api_url
 
 __all__ = [
     'PythonActionWrapper'
 ]
 
 LOG = logging.getLogger(__name__)
+
+class DatastoreService(object):
+    """
+    Instance of this class is passed to the python action runner and exposes "public"
+    methods which can be called by the action.
+    """
+
+    DATASTORE_NAME_SEPARATOR = ':'
+
+    def __init__(self, logger, pack_name, class_name, api_username):
+        self._api_username = api_username
+        self._pack_name = pack_name
+        self._class_name = class_name
+        self._logger = logger
+
+        self._client = None
+
+    ##################################
+    # Methods for datastore management
+    ##################################
+
+    def list_values(self, local=True, prefix=None):
+        """
+        Retrieve all the datastores items.
+
+        :param local: List values from a namespace local to this sensor. Defaults to True.
+        :type: local: ``bool``
+
+        :param prefix: Optional key name prefix / startswith filter.
+        :type prefix: ``str``
+
+        :rtype: ``list`` of :class:`KeyValuePair`
+        """
+        client = self._get_api_client()
+        self._logger.audit('Retrieving all the value from the datastore')
+
+        key_prefix = self._get_full_key_prefix(local=local, prefix=prefix)
+        kvps = client.keys.get_all(prefix=key_prefix)
+        return kvps
+
+    def get_value(self, name, local=True):
+        """
+        Retrieve a value from the datastore for the provided key.
+
+        By default, value is retrieved from the namespace local to the sensor. If you want to
+        retrieve a global value from a datastore, pass local=False to this method.
+
+        :param name: Key name.
+        :type name: ``str``
+
+        :param local: Retrieve value from a namespace local to the sensor. Defaults to True.
+        :type: local: ``bool``
+
+        :rtype: ``str`` or ``None``
+        """
+        name = self._get_full_key_name(name=name, local=local)
+
+        client = self._get_api_client()
+        self._logger.audit('Retrieving value from the datastore (name=%s)', name)
+
+        try:
+            kvp = client.keys.get_by_id(id=name)
+        except Exception:
+            return None
+
+        if kvp:
+            return kvp.value
+
+        return None
+
+    def set_value(self, name, value, ttl=None, local=True):
+        """
+        Set a value for the provided key.
+
+        By default, value is set in a namespace local to the sensor. If you want to
+        set a global value, pass local=False to this method.
+
+        :param name: Key name.
+        :type name: ``str``
+
+        :param value: Key value.
+        :type value: ``str``
+
+        :param ttl: Optional TTL (in seconds).
+        :type ttl: ``int``
+
+        :param local: Set value in a namespace local to the sensor. Defaults to True.
+        :type: local: ``bool``
+
+        :return: ``True`` on success, ``False`` otherwise.
+        :rtype: ``bool``
+        """
+        name = self._get_full_key_name(name=name, local=local)
+
+        value = str(value)
+        client = self._get_api_client()
+
+        self._logger.audit('Setting value in the datastore (name=%s)', name)
+
+        instance = KeyValuePair()
+        instance.id = name
+        instance.name = name
+        instance.value = value
+
+        if ttl:
+            instance.ttl = ttl
+
+        client.keys.update(instance=instance)
+        return True
+
+    def delete_value(self, name, local=True):
+        """
+        Delete the provided key.
+
+        By default, value is deleted from a namespace local to the sensor. If you want to
+        delete a global value, pass local=False to this method.
+
+        :param name: Name of the key to delete.
+        :type name: ``str``
+
+        :param local: Delete a value in a namespace local to the sensor. Defaults to True.
+        :type: local: ``bool``
+
+        :return: ``True`` on success, ``False`` otherwise.
+        :rtype: ``bool``
+        """
+        name = self._get_full_key_name(name=name, local=local)
+
+        client = self._get_api_client()
+
+        instance = KeyValuePair()
+        instance.id = name
+        instance.name = name
+
+        self._logger.audit('Deleting value from the datastore (name=%s)', name)
+
+        try:
+            client.keys.delete(instance=instance)
+        except Exception:
+            return False
+
+        return True
+
+    def _get_api_client(self):
+        """
+        Retrieve API client instance.
+        """
+        if not self._client:
+            ttl = (24 * 60 * 60)
+            temporary_token = create_token(username=self._api_username, ttl=ttl)
+            api_url = get_full_public_api_url()
+            self._client = Client(api_url=api_url, token=temporary_token.token)
+
+        return self._client
+
+    def _get_full_key_name(self, name, local):
+        """
+        Retrieve a full key name.
+
+        :rtype: ``str``
+        """
+        if local:
+            name = self._get_key_name_with_sensor_prefix(name=name)
+
+        return name
+
+    def _get_full_key_prefix(self, local, prefix=None):
+        if local:
+            key_prefix = self._get_sensor_local_key_name_prefix()
+
+            if prefix:
+                key_prefix += prefix
+        else:
+            key_prefix = prefix
+
+        return key_prefix
+
+    def _get_sensor_local_key_name_prefix(self):
+        """
+        Retrieve key prefix which is local to this sensor.
+        """
+        key_prefix = self._get_datastore_key_prefix() + self.DATASTORE_NAME_SEPARATOR
+        return key_prefix
+
+    def _get_key_name_with_sensor_prefix(self, name):
+        """
+        Retrieve a full key name which is local to the current sensor.
+
+        :param name: Base datastore key name.
+        :type name: ``str``
+
+        :rtype: ``str``
+        """
+        prefix = self._get_datastore_key_prefix()
+        full_name = prefix + self.DATASTORE_NAME_SEPARATOR + name
+        return full_name
+
+    def _get_datastore_key_prefix(self):
+        prefix = '%s.%s' % (self._pack_name, self._class_name)
+        return prefix
 
 
 class PythonActionWrapper(object):
@@ -46,10 +252,15 @@ class PythonActionWrapper(object):
         :param parent_args: Command line arguments passed to the parent process.
         :type parse_args: ``list``
         """
+        db_setup()
+        
         self._pack = pack
         self._file_path = file_path
         self._parameters = parameters or {}
         self._parent_args = parent_args or []
+        self._class_name = None
+        self._logger = logging.getLogger('PythonActionWrapper')
+        # logging.setup(cfg.CONF.actionrunner.logging)
 
         try:
             config.parse_args(args=self._parent_args)
@@ -81,6 +292,10 @@ class PythonActionWrapper(object):
         config_parser = ContentPackConfigParser(pack_name=self._pack)
         config = config_parser.get_action_config(action_file_path=self._file_path)
 
+        action_cls.datastore = DatastoreService(logger=self._set_up_logger(),
+                                                pack_name=self._pack,
+                                                class_name=action_cls.__name__,
+                                                api_username="action_service")
         if config:
             LOG.info('Using config "%s" for action "%s"' % (config.file_path,
                                                             self._file_path))
@@ -89,6 +304,23 @@ class PythonActionWrapper(object):
         else:
             LOG.info('No config found for action "%s"' % (self._file_path))
             return action_cls(config={})
+
+    def _set_up_logger(self):
+        """
+        Set up a logger which logs all the messages with level DEBUG
+        and above to stderr.
+        """
+        logger = logging.getLogger('PythonActionWrapper')
+
+        console = stdlib_logging.StreamHandler()
+        console.setLevel(stdlib_logging.DEBUG)
+
+        formatter = stdlib_logging.Formatter('%(name)-12s: %(levelname)-8s %(message)s')
+        console.setFormatter(formatter)
+        logger.addHandler(console)
+        logger.setLevel(stdlib_logging.DEBUG)
+
+        return logger
 
 
 if __name__ == '__main__':

--- a/st2actions/st2actions/runners/python_action_wrapper.py
+++ b/st2actions/st2actions/runners/python_action_wrapper.py
@@ -57,7 +57,6 @@ class PythonActionWrapper(object):
         self._parent_args = parent_args or []
         self._class_name = None
         self._logger = logging.getLogger('PythonActionWrapper')
-        # logging.setup(cfg.CONF.actionrunner.logging)
 
         try:
             config.parse_args(args=self._parent_args)

--- a/st2actions/st2actions/runners/python_action_wrapper.py
+++ b/st2actions/st2actions/runners/python_action_wrapper.py
@@ -21,220 +21,17 @@ import logging as stdlib_logging
 from st2common import log as logging
 from st2actions import config
 from st2actions.runners.pythonrunner import Action
-from st2client.client import Client
-from st2client.models import KeyValuePair
 from st2common.util import loader as action_loader
 from st2common.util.config_parser import ContentPackConfigParser
 from st2common.constants.action import ACTION_OUTPUT_RESULT_DELIMITER
 from st2common.service_setup import db_setup
-from st2common.services.access import create_token
-from st2common.util.api import get_full_public_api_url
+from st2common.services.datastore import DatastoreService
 
 __all__ = [
     'PythonActionWrapper'
 ]
 
 LOG = logging.getLogger(__name__)
-
-class DatastoreService(object):
-    """
-    Instance of this class is passed to the python action runner and exposes "public"
-    methods which can be called by the action.
-    """
-
-    DATASTORE_NAME_SEPARATOR = ':'
-
-    def __init__(self, logger, pack_name, class_name, api_username):
-        self._api_username = api_username
-        self._pack_name = pack_name
-        self._class_name = class_name
-        self._logger = logger
-
-        self._client = None
-
-    ##################################
-    # Methods for datastore management
-    ##################################
-
-    def list_values(self, local=True, prefix=None):
-        """
-        Retrieve all the datastores items.
-
-        :param local: List values from a namespace local to this sensor. Defaults to True.
-        :type: local: ``bool``
-
-        :param prefix: Optional key name prefix / startswith filter.
-        :type prefix: ``str``
-
-        :rtype: ``list`` of :class:`KeyValuePair`
-        """
-        client = self._get_api_client()
-        self._logger.audit('Retrieving all the value from the datastore')
-
-        key_prefix = self._get_full_key_prefix(local=local, prefix=prefix)
-        kvps = client.keys.get_all(prefix=key_prefix)
-        return kvps
-
-    def get_value(self, name, local=True):
-        """
-        Retrieve a value from the datastore for the provided key.
-
-        By default, value is retrieved from the namespace local to the sensor. If you want to
-        retrieve a global value from a datastore, pass local=False to this method.
-
-        :param name: Key name.
-        :type name: ``str``
-
-        :param local: Retrieve value from a namespace local to the sensor. Defaults to True.
-        :type: local: ``bool``
-
-        :rtype: ``str`` or ``None``
-        """
-        name = self._get_full_key_name(name=name, local=local)
-
-        client = self._get_api_client()
-        self._logger.audit('Retrieving value from the datastore (name=%s)', name)
-
-        try:
-            kvp = client.keys.get_by_id(id=name)
-        except Exception:
-            return None
-
-        if kvp:
-            return kvp.value
-
-        return None
-
-    def set_value(self, name, value, ttl=None, local=True):
-        """
-        Set a value for the provided key.
-
-        By default, value is set in a namespace local to the sensor. If you want to
-        set a global value, pass local=False to this method.
-
-        :param name: Key name.
-        :type name: ``str``
-
-        :param value: Key value.
-        :type value: ``str``
-
-        :param ttl: Optional TTL (in seconds).
-        :type ttl: ``int``
-
-        :param local: Set value in a namespace local to the sensor. Defaults to True.
-        :type: local: ``bool``
-
-        :return: ``True`` on success, ``False`` otherwise.
-        :rtype: ``bool``
-        """
-        name = self._get_full_key_name(name=name, local=local)
-
-        value = str(value)
-        client = self._get_api_client()
-
-        self._logger.audit('Setting value in the datastore (name=%s)', name)
-
-        instance = KeyValuePair()
-        instance.id = name
-        instance.name = name
-        instance.value = value
-
-        if ttl:
-            instance.ttl = ttl
-
-        client.keys.update(instance=instance)
-        return True
-
-    def delete_value(self, name, local=True):
-        """
-        Delete the provided key.
-
-        By default, value is deleted from a namespace local to the sensor. If you want to
-        delete a global value, pass local=False to this method.
-
-        :param name: Name of the key to delete.
-        :type name: ``str``
-
-        :param local: Delete a value in a namespace local to the sensor. Defaults to True.
-        :type: local: ``bool``
-
-        :return: ``True`` on success, ``False`` otherwise.
-        :rtype: ``bool``
-        """
-        name = self._get_full_key_name(name=name, local=local)
-
-        client = self._get_api_client()
-
-        instance = KeyValuePair()
-        instance.id = name
-        instance.name = name
-
-        self._logger.audit('Deleting value from the datastore (name=%s)', name)
-
-        try:
-            client.keys.delete(instance=instance)
-        except Exception:
-            return False
-
-        return True
-
-    def _get_api_client(self):
-        """
-        Retrieve API client instance.
-        """
-        if not self._client:
-            ttl = (24 * 60 * 60)
-            temporary_token = create_token(username=self._api_username, ttl=ttl)
-            api_url = get_full_public_api_url()
-            self._client = Client(api_url=api_url, token=temporary_token.token)
-
-        return self._client
-
-    def _get_full_key_name(self, name, local):
-        """
-        Retrieve a full key name.
-
-        :rtype: ``str``
-        """
-        if local:
-            name = self._get_key_name_with_sensor_prefix(name=name)
-
-        return name
-
-    def _get_full_key_prefix(self, local, prefix=None):
-        if local:
-            key_prefix = self._get_sensor_local_key_name_prefix()
-
-            if prefix:
-                key_prefix += prefix
-        else:
-            key_prefix = prefix
-
-        return key_prefix
-
-    def _get_sensor_local_key_name_prefix(self):
-        """
-        Retrieve key prefix which is local to this sensor.
-        """
-        key_prefix = self._get_datastore_key_prefix() + self.DATASTORE_NAME_SEPARATOR
-        return key_prefix
-
-    def _get_key_name_with_sensor_prefix(self, name):
-        """
-        Retrieve a full key name which is local to the current sensor.
-
-        :param name: Base datastore key name.
-        :type name: ``str``
-
-        :rtype: ``str``
-        """
-        prefix = self._get_datastore_key_prefix()
-        full_name = prefix + self.DATASTORE_NAME_SEPARATOR + name
-        return full_name
-
-    def _get_datastore_key_prefix(self):
-        prefix = '%s.%s' % (self._pack_name, self._class_name)
-        return prefix
 
 
 class PythonActionWrapper(object):
@@ -253,7 +50,7 @@ class PythonActionWrapper(object):
         :type parse_args: ``list``
         """
         db_setup()
-        
+
         self._pack = pack
         self._file_path = file_path
         self._parameters = parameters or {}

--- a/st2common/st2common/services/datastore.py
+++ b/st2common/st2common/services/datastore.py
@@ -21,8 +21,7 @@ from st2common.util.api import get_full_public_api_url
 
 class DatastoreService(object):
     """
-    Instance of this class is passed to the python action runner and exposes "public"
-    methods which can be called by the action.
+    Class provides public methods for accessing datastore items.
     """
 
     DATASTORE_NAME_SEPARATOR = ':'

--- a/st2common/st2common/services/datastore.py
+++ b/st2common/st2common/services/datastore.py
@@ -1,0 +1,220 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from st2client.client import Client
+from st2client.models import KeyValuePair
+from st2common.services.access import create_token
+from st2common.util.api import get_full_public_api_url
+
+
+class DatastoreService(object):
+    """
+    Instance of this class is passed to the python action runner and exposes "public"
+    methods which can be called by the action.
+    """
+
+    DATASTORE_NAME_SEPARATOR = ':'
+
+    def __init__(self, logger, pack_name, class_name, api_username):
+        self._api_username = api_username
+        self._pack_name = pack_name
+        self._class_name = class_name
+        self._logger = logger
+
+        self._client = None
+
+    ##################################
+    # Methods for datastore management
+    ##################################
+
+    def list_values(self, local=True, prefix=None):
+        """
+        Retrieve all the datastores items.
+
+        :param local: List values from a namespace local to this sensor. Defaults to True.
+        :type: local: ``bool``
+
+        :param prefix: Optional key name prefix / startswith filter.
+        :type prefix: ``str``
+
+        :rtype: ``list`` of :class:`KeyValuePair`
+        """
+        client = self._get_api_client()
+        self._logger.audit('Retrieving all the value from the datastore')
+
+        key_prefix = self._get_full_key_prefix(local=local, prefix=prefix)
+        kvps = client.keys.get_all(prefix=key_prefix)
+        return kvps
+
+    def get_value(self, name, local=True):
+        """
+        Retrieve a value from the datastore for the provided key.
+
+        By default, value is retrieved from the namespace local to the sensor. If you want to
+        retrieve a global value from a datastore, pass local=False to this method.
+
+        :param name: Key name.
+        :type name: ``str``
+
+        :param local: Retrieve value from a namespace local to the sensor. Defaults to True.
+        :type: local: ``bool``
+
+        :rtype: ``str`` or ``None``
+        """
+        name = self._get_full_key_name(name=name, local=local)
+
+        client = self._get_api_client()
+        self._logger.audit('Retrieving value from the datastore (name=%s)', name)
+
+        try:
+            kvp = client.keys.get_by_id(id=name)
+        except Exception:
+            return None
+
+        if kvp:
+            return kvp.value
+
+        return None
+
+    def set_value(self, name, value, ttl=None, local=True):
+        """
+        Set a value for the provided key.
+
+        By default, value is set in a namespace local to the sensor. If you want to
+        set a global value, pass local=False to this method.
+
+        :param name: Key name.
+        :type name: ``str``
+
+        :param value: Key value.
+        :type value: ``str``
+
+        :param ttl: Optional TTL (in seconds).
+        :type ttl: ``int``
+
+        :param local: Set value in a namespace local to the sensor. Defaults to True.
+        :type: local: ``bool``
+
+        :return: ``True`` on success, ``False`` otherwise.
+        :rtype: ``bool``
+        """
+        name = self._get_full_key_name(name=name, local=local)
+
+        value = str(value)
+        client = self._get_api_client()
+
+        self._logger.audit('Setting value in the datastore (name=%s)', name)
+
+        instance = KeyValuePair()
+        instance.id = name
+        instance.name = name
+        instance.value = value
+
+        if ttl:
+            instance.ttl = ttl
+
+        client.keys.update(instance=instance)
+        return True
+
+    def delete_value(self, name, local=True):
+        """
+        Delete the provided key.
+
+        By default, value is deleted from a namespace local to the sensor. If you want to
+        delete a global value, pass local=False to this method.
+
+        :param name: Name of the key to delete.
+        :type name: ``str``
+
+        :param local: Delete a value in a namespace local to the sensor. Defaults to True.
+        :type: local: ``bool``
+
+        :return: ``True`` on success, ``False`` otherwise.
+        :rtype: ``bool``
+        """
+        name = self._get_full_key_name(name=name, local=local)
+
+        client = self._get_api_client()
+
+        instance = KeyValuePair()
+        instance.id = name
+        instance.name = name
+
+        self._logger.audit('Deleting value from the datastore (name=%s)', name)
+
+        try:
+            client.keys.delete(instance=instance)
+        except Exception:
+            return False
+
+        return True
+
+    def _get_api_client(self):
+        """
+        Retrieve API client instance.
+        """
+        if not self._client:
+            ttl = (24 * 60 * 60)
+            temporary_token = create_token(username=self._api_username, ttl=ttl)
+            api_url = get_full_public_api_url()
+            self._client = Client(api_url=api_url, token=temporary_token.token)
+
+        return self._client
+
+    def _get_full_key_name(self, name, local):
+        """
+        Retrieve a full key name.
+
+        :rtype: ``str``
+        """
+        if local:
+            name = self._get_key_name_with_sensor_prefix(name=name)
+
+        return name
+
+    def _get_full_key_prefix(self, local, prefix=None):
+        if local:
+            key_prefix = self._get_sensor_local_key_name_prefix()
+
+            if prefix:
+                key_prefix += prefix
+        else:
+            key_prefix = prefix
+
+        return key_prefix
+
+    def _get_sensor_local_key_name_prefix(self):
+        """
+        Retrieve key prefix which is local to this sensor.
+        """
+        key_prefix = self._get_datastore_key_prefix() + self.DATASTORE_NAME_SEPARATOR
+        return key_prefix
+
+    def _get_key_name_with_sensor_prefix(self, name):
+        """
+        Retrieve a full key name which is local to the current sensor.
+
+        :param name: Base datastore key name.
+        :type name: ``str``
+
+        :rtype: ``str``
+        """
+        prefix = self._get_datastore_key_prefix()
+        full_name = prefix + self.DATASTORE_NAME_SEPARATOR + name
+        return full_name
+
+    def _get_datastore_key_prefix(self):
+        prefix = '%s.%s' % (self._pack_name, self._class_name)
+        return prefix

--- a/st2common/st2common/services/datastore.py
+++ b/st2common/st2common/services/datastore.py
@@ -42,7 +42,7 @@ class DatastoreService(object):
         """
         Retrieve all the datastores items.
 
-        :param local: List values from a namespace local to this sensor. Defaults to True.
+        :param local: List values from a namespace local to this pack/class. Defaults to True.
         :type: local: ``bool``
 
         :param prefix: Optional key name prefix / startswith filter.
@@ -61,13 +61,13 @@ class DatastoreService(object):
         """
         Retrieve a value from the datastore for the provided key.
 
-        By default, value is retrieved from the namespace local to the sensor. If you want to
+        By default, value is retrieved from the namespace local to the pack/class. If you want to
         retrieve a global value from a datastore, pass local=False to this method.
 
         :param name: Key name.
         :type name: ``str``
 
-        :param local: Retrieve value from a namespace local to the sensor. Defaults to True.
+        :param local: Retrieve value from a namespace local to the pack/class. Defaults to True.
         :type: local: ``bool``
 
         :rtype: ``str`` or ``None``
@@ -91,7 +91,7 @@ class DatastoreService(object):
         """
         Set a value for the provided key.
 
-        By default, value is set in a namespace local to the sensor. If you want to
+        By default, value is set in a namespace local to the pack/class. If you want to
         set a global value, pass local=False to this method.
 
         :param name: Key name.
@@ -103,7 +103,7 @@ class DatastoreService(object):
         :param ttl: Optional TTL (in seconds).
         :type ttl: ``int``
 
-        :param local: Set value in a namespace local to the sensor. Defaults to True.
+        :param local: Set value in a namespace local to the pack/class. Defaults to True.
         :type: local: ``bool``
 
         :return: ``True`` on success, ``False`` otherwise.
@@ -131,13 +131,13 @@ class DatastoreService(object):
         """
         Delete the provided key.
 
-        By default, value is deleted from a namespace local to the sensor. If you want to
+        By default, value is deleted from a namespace local to the pack/class. If you want to
         delete a global value, pass local=False to this method.
 
         :param name: Name of the key to delete.
         :type name: ``str``
 
-        :param local: Delete a value in a namespace local to the sensor. Defaults to True.
+        :param local: Delete a value in a namespace local to the pack/class. Defaults to True.
         :type: local: ``bool``
 
         :return: ``True`` on success, ``False`` otherwise.
@@ -179,13 +179,13 @@ class DatastoreService(object):
         :rtype: ``str``
         """
         if local:
-            name = self._get_key_name_with_sensor_prefix(name=name)
+            name = self._get_key_name_with_prefix(name=name)
 
         return name
 
     def _get_full_key_prefix(self, local, prefix=None):
         if local:
-            key_prefix = self._get_sensor_local_key_name_prefix()
+            key_prefix = self._get_local_key_name_prefix()
 
             if prefix:
                 key_prefix += prefix
@@ -194,16 +194,16 @@ class DatastoreService(object):
 
         return key_prefix
 
-    def _get_sensor_local_key_name_prefix(self):
+    def _get_local_key_name_prefix(self):
         """
-        Retrieve key prefix which is local to this sensor.
+        Retrieve key prefix which is local to this pack/class.
         """
         key_prefix = self._get_datastore_key_prefix() + self.DATASTORE_NAME_SEPARATOR
         return key_prefix
 
-    def _get_key_name_with_sensor_prefix(self, name):
+    def _get_key_name_with_prefix(self, name):
         """
-        Retrieve a full key name which is local to the current sensor.
+        Retrieve a full key name which is local to the current pack/class.
 
         :param name: Base datastore key name.
         :type name: ``str``

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -52,8 +52,6 @@ class SensorService(object):
     methods which can be called by the sensor.
     """
 
-    DATASTORE_NAME_SEPARATOR = ':'
-
     def __init__(self, sensor_wrapper):
         self._sensor_wrapper = sensor_wrapper
         self._logger = self._sensor_wrapper._logger

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -21,7 +21,6 @@ import argparse
 
 import eventlet
 from oslo_config import cfg
-from st2client.client import Client
 
 from st2common import log as logging
 from st2common.logging.misc import set_log_level_for_all_loggers
@@ -33,9 +32,7 @@ from st2common.util.config_parser import ContentPackConfigParser
 from st2common.services.triggerwatcher import TriggerWatcher
 from st2reactor.sensor.base import Sensor, PollingSensor
 from st2reactor.sensor import config
-from st2common.constants.system import API_URL_ENV_VARIABLE_NAME
-from st2common.constants.system import AUTH_TOKEN_ENV_VARIABLE_NAME
-from st2client.models.keyvalue import KeyValuePair
+from st2common.services.datastore import DatastoreService
 
 __all__ = [
     'SensorWrapper'
@@ -61,6 +58,10 @@ class SensorService(object):
         self._sensor_wrapper = sensor_wrapper
         self._logger = self._sensor_wrapper._logger
         self._dispatcher = TriggerDispatcher(self._logger)
+        self._datastore_service = DatastoreService(logger=self._logger,
+                                                   pack_name=self._sensor_wrapper._pack,
+                                                   class_name=self._sensor_wrapper._class_name,
+                                                   api_username='sensor_service')
 
         self._client = None
 
@@ -111,190 +112,16 @@ class SensorService(object):
     ##################################
 
     def list_values(self, local=True, prefix=None):
-        """
-        Retrieve all the datastores items.
-
-        :param local: List values from a namespace local to this sensor. Defaults to True.
-        :type: local: ``bool``
-
-        :param prefix: Optional key name prefix / startswith filter.
-        :type prefix: ``str``
-
-        :rtype: ``list`` of :class:`KeyValuePair`
-        """
-        client = self._get_api_client()
-        self._logger.audit('Retrieving all the value from the datastore')
-
-        key_prefix = self._get_full_key_prefix(local=local, prefix=prefix)
-        kvps = client.keys.get_all(prefix=key_prefix)
-        return kvps
+        return self._datastore_service.list_values(local, prefix)
 
     def get_value(self, name, local=True):
-        """
-        Retrieve a value from the datastore for the provided key.
-
-        By default, value is retrieved from the namespace local to the sensor. If you want to
-        retrieve a global value from a datastore, pass local=False to this method.
-
-        :param name: Key name.
-        :type name: ``str``
-
-        :param local: Retrieve value from a namespace local to the sensor. Defaults to True.
-        :type: local: ``bool``
-
-        :rtype: ``str`` or ``None``
-        """
-        name = self._get_full_key_name(name=name, local=local)
-
-        client = self._get_api_client()
-        self._logger.audit('Retrieving value from the datastore (name=%s)', name)
-
-        try:
-            kvp = client.keys.get_by_id(id=name)
-        except Exception:
-            return None
-
-        if kvp:
-            return kvp.value
-
-        return None
+        return self._datastore_service.get_value(name, local)
 
     def set_value(self, name, value, ttl=None, local=True):
-        """
-        Set a value for the provided key.
-
-        By default, value is set in a namespace local to the sensor. If you want to
-        set a global value, pass local=False to this method.
-
-        :param name: Key name.
-        :type name: ``str``
-
-        :param value: Key value.
-        :type value: ``str``
-
-        :param ttl: Optional TTL (in seconds).
-        :type ttl: ``int``
-
-        :param local: Set value in a namespace local to the sensor. Defaults to True.
-        :type: local: ``bool``
-
-        :return: ``True`` on success, ``False`` otherwise.
-        :rtype: ``bool``
-        """
-        name = self._get_full_key_name(name=name, local=local)
-
-        value = str(value)
-        client = self._get_api_client()
-
-        self._logger.audit('Setting value in the datastore (name=%s)', name)
-
-        instance = KeyValuePair()
-        instance.id = name
-        instance.name = name
-        instance.value = value
-
-        if ttl:
-            instance.ttl = ttl
-
-        client.keys.update(instance=instance)
-        return True
+        return self._datastore_service.set_value(name, value, ttl, local)
 
     def delete_value(self, name, local=True):
-        """
-        Delete the provided key.
-
-        By default, value is deleted from a namespace local to the sensor. If you want to
-        delete a global value, pass local=False to this method.
-
-        :param name: Name of the key to delete.
-        :type name: ``str``
-
-        :param local: Delete a value in a namespace local to the sensor. Defaults to True.
-        :type: local: ``bool``
-
-        :return: ``True`` on success, ``False`` otherwise.
-        :rtype: ``bool``
-        """
-        name = self._get_full_key_name(name=name, local=local)
-
-        client = self._get_api_client()
-
-        instance = KeyValuePair()
-        instance.id = name
-        instance.name = name
-
-        self._logger.audit('Deleting value from the datastore (name=%s)', name)
-
-        try:
-            client.keys.delete(instance=instance)
-        except Exception:
-            return False
-
-        return True
-
-    def _get_api_client(self):
-        """
-        Retrieve API client instance.
-        """
-        # TODO: API client is really unfriendly and needs to be re-designed and
-        # improved
-        api_url = os.environ.get(API_URL_ENV_VARIABLE_NAME, None)
-        auth_token = os.environ.get(AUTH_TOKEN_ENV_VARIABLE_NAME, None)
-
-        if not api_url or not auth_token:
-            raise ValueError('%s and %s environment variable must be set' %
-                             (API_URL_ENV_VARIABLE_NAME, AUTH_TOKEN_ENV_VARIABLE_NAME))
-
-        if not self._client:
-            self._client = Client(api_url=api_url)
-
-        return self._client
-
-    def _get_full_key_name(self, name, local):
-        """
-        Retrieve a full key name.
-
-        :rtype: ``str``
-        """
-        if local:
-            name = self._get_key_name_with_sensor_prefix(name=name)
-
-        return name
-
-    def _get_full_key_prefix(self, local, prefix=None):
-        if local:
-            key_prefix = self._get_sensor_local_key_name_prefix()
-
-            if prefix:
-                key_prefix += prefix
-        else:
-            key_prefix = prefix
-
-        return key_prefix
-
-    def _get_sensor_local_key_name_prefix(self):
-        """
-        Retrieve key prefix which is local to this sensor.
-        """
-        key_prefix = self._get_datastore_key_prefix() + self.DATASTORE_NAME_SEPARATOR
-        return key_prefix
-
-    def _get_key_name_with_sensor_prefix(self, name):
-        """
-        Retrieve a full key name which is local to the current sensor.
-
-        :param name: Base datastore key name.
-        :type name: ``str``
-
-        :rtype: ``str``
-        """
-        prefix = self._get_datastore_key_prefix()
-        full_name = prefix + self.DATASTORE_NAME_SEPARATOR + name
-        return full_name
-
-    def _get_datastore_key_prefix(self):
-        prefix = '%s.%s' % (self._sensor_wrapper._pack, self._sensor_wrapper._class_name)
-        return prefix
+        return self._datastore_service.delete_value(name, local)
 
 
 class SensorWrapper(object):

--- a/st2reactor/tests/unit/test_sensor_wrapper.py
+++ b/st2reactor/tests/unit/test_sensor_wrapper.py
@@ -185,4 +185,4 @@ class SensorServiceTestCase(unittest2.TestCase):
     def _set_mock_api_client(self, mock_api_client):
         mock_method = mock.Mock()
         mock_method.return_value = mock_api_client
-        self._sensor_service._get_api_client = mock_method
+        self._sensor_service._datastore_service._get_api_client = mock_method

--- a/st2tests/st2tests/mocks/datastore.py
+++ b/st2tests/st2tests/mocks/datastore.py
@@ -1,0 +1,92 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Mock classes for use in pack testing.
+"""
+
+from st2common.services.datastore import DatastoreService
+from st2client.models.keyvalue import KeyValuePair
+
+__all__ = [
+    'MockDatastoreService'
+]
+
+
+class MockDatastoreService(DatastoreService):
+    """
+    Mock DatastoreService for use in testing.
+    """
+    def __init__(self, logger, pack_name, class_name, api_username):
+        # Holds mock KeyValuePair objects
+        # Key is a KeyValuePair name and value is the KeyValuePair object
+        self._datastore_items = {}
+
+    def list_values(self, local=True, prefix=None):
+        """
+        Return a list of all values stored in a dictionary which is local to this class.
+        """
+        key_prefix = self._get_full_key_prefix(local=local, prefix=prefix)
+
+        if not key_prefix:
+            return self._datastore_items.values()
+
+        result = []
+        for name, kvp in self._datastore_items.items():
+            if name.startswith(key_prefix):
+                result.append(kvp)
+
+        return result
+
+    def get_value(self, name, local=True):
+        """
+        Return a particular value stored in a dictionary which is local to this class.
+        """
+        name = self._get_full_key_name(name=name, local=local)
+
+        if name not in self._datastore_items:
+            return None
+
+        kvp = self._datastore_items[name]
+        return kvp.value
+
+    def set_value(self, name, value, ttl=None, local=True):
+        """
+        Store a value in a dictionary which is local to this class.
+        """
+        if ttl:
+            raise ValueError('MockSensorService.set_value doesn\'t support "ttl" argument')
+
+        name = self._get_full_key_name(name=name, local=local)
+
+        instance = KeyValuePair()
+        instance.id = name
+        instance.name = name
+        instance.value = value
+
+        self._datastore_items[name] = instance
+        return True
+
+    def delete_value(self, name, local=True):
+        """
+        Delete a value from a dictionary which is local to this class.
+        """
+        name = self._get_full_key_name(name=name, local=local)
+
+        if name not in self._datastore_items:
+            return False
+
+        del self._datastore_items[name]
+        return True

--- a/st2tests/st2tests/mocks/datastore.py
+++ b/st2tests/st2tests/mocks/datastore.py
@@ -30,6 +30,9 @@ class MockDatastoreService(DatastoreService):
     Mock DatastoreService for use in testing.
     """
     def __init__(self, logger, pack_name, class_name, api_username):
+        self._pack_name = pack_name
+        self._class_name = class_name
+
         # Holds mock KeyValuePair objects
         # Key is a KeyValuePair name and value is the KeyValuePair object
         self._datastore_items = {}

--- a/st2tests/st2tests/mocks/datastore.py
+++ b/st2tests/st2tests/mocks/datastore.py
@@ -70,7 +70,7 @@ class MockDatastoreService(DatastoreService):
         Store a value in a dictionary which is local to this class.
         """
         if ttl:
-            raise ValueError('MockSensorService.set_value doesn\'t support "ttl" argument')
+            raise ValueError('MockDatastoreService.set_value doesn\'t support "ttl" argument')
 
         name = self._get_full_key_name(name=name, local=local)
 


### PR DESCRIPTION
Initial pass at giving python actions easy access to the key/value store. Attempted to keep the API similar to sensors without duplicating the code. I'm sure the stackstorm folks will have feedback.

Adding the datastore attribute to the action class in python_action_wrapper.py is ugly, but I couldn't think of a better way with out breaking actions by changing the Action.**init** signature.
