### PR TITLE
optional debug tmp dir

### DIFF
--- a/st2debug/st2debug/cmd/submit_debug_info.py
+++ b/st2debug/st2debug/cmd/submit_debug_info.py
@@ -166,6 +166,7 @@ class DebugInfoCollector(object):
         self.output_path = output_path
 
         config_file = config_file or {}
+        self.tmp_dir_prefix = config_file.get('st2_debug_tmp_path', None)
         self.st2_config_file_path = config_file.get('st2_config_file_path', ST2_CONFIG_FILE_PATH)
         self.mistral_config_file_path = config_file.get('mistral_config_file_path',
                                                         MISTRAL_CONFIG_FILE_PATH)
@@ -227,7 +228,7 @@ class DebugInfoCollector(object):
         finally:
             # Remove temp files
             for temp_file in temp_files:
-                assert temp_file.startswith('/tmp')
+                assert temp_file.startswith(self.tmp_dir_prefix)
                 remove_file(file_path=temp_file)
 
     def create_archive(self):
@@ -272,7 +273,7 @@ class DebugInfoCollector(object):
 
         finally:
             # Ensure temp files are removed regardless of success or failure
-            assert self._temp_dir_path.startswith('/tmp')
+            assert self._temp_dir_path.startswith(self.tmp_dir_prefix)
             remove_dir(self._temp_dir_path)
 
     def encrypt_archive(self, archive_file_path):
@@ -297,7 +298,7 @@ class DebugInfoCollector(object):
             assert import_result.count == 1
 
             encrypted_archive_output_file_name = os.path.basename(archive_file_path) + '.asc'
-            encrypted_archive_output_file_path = os.path.join('/tmp',
+            encrypted_archive_output_file_path = os.path.join(self.tmp_dir_prefix,
                                                               encrypted_archive_output_file_name)
             with open(archive_file_path, 'rb') as fp:
                 gpg.encrypt_file(file=fp,
@@ -354,13 +355,12 @@ class DebugInfoCollector(object):
         copy_files(file_paths=self.config_file_paths, destination=output_path)
 
         st2_config_path = os.path.join(output_path, self.st2_config_file_name)
-        process_st2_config(config_path=st2_config_path)
+        process_st2_config(config_path=st2_config_path, tmp_prefix=self.tmp_dir_prefix)
 
         mistral_config_path = os.path.join(output_path, self.mistral_config_file_name)
-        process_mistral_config(config_path=mistral_config_path)
+        process_mistral_config(config_path=mistral_config_path, tmp_prefix=self.tmp_dir_prefix)
 
-    @staticmethod
-    def collect_pack_content(output_path):
+    def collect_pack_content(self, output_path):
         """
         Copy pack contents to the output path.
 
@@ -384,7 +384,7 @@ class DebugInfoCollector(object):
             pack_dirs = get_dirs_in_path(file_path=base_pack_dir)
 
             for pack_dir in pack_dirs:
-                process_content_pack_dir(pack_dir=pack_dir)
+                process_content_pack_dir(pack_dir=pack_dir, tmp_prefix=self.tmp_dir_prefix)
 
     def add_system_information(self, output_path):
         """
@@ -438,9 +438,10 @@ class DebugInfoCollector(object):
         Create tarball with the contents of temp_dir_path.
 
         Tarball will be written to self.output_path, if set. Otherwise it will
-        be written to /tmp a name generated according to OUTPUT_FILENAME_TEMPLATE.
+        be written to self.tmp_dir_prefix with a name generated according to
+        OUTPUT_FILENAME_TEMPLATE.
 
-        :param temp_dir_path: Base directory to include in tarbal.
+        :param temp_dir_path: Base directory to include in tarball.
         :type temp_dir_path: ``str``
 
         :return: Path to the created tarball.
@@ -454,15 +455,14 @@ class DebugInfoCollector(object):
             values = {'hostname': socket.gethostname(), 'date': date}
 
             output_file_name = OUTPUT_FILENAME_TEMPLATE % values
-            output_file_path = os.path.join('/tmp', output_file_name)
+            output_file_path = os.path.join(self.tmp_dir_prefix, output_file_name)
 
         with tarfile.open(output_file_path, 'w:gz') as tar:
             tar.add(temp_dir_path, arcname='')
 
         return output_file_path
 
-    @staticmethod
-    def create_temp_directories():
+    def create_temp_directories(self):
         """
         Creates a new temp directory and creates the directory structure as defined
         by DIRECTORY_STRUCTURE.
@@ -470,7 +470,12 @@ class DebugInfoCollector(object):
         :return: Path to temp directory.
         :rtype: ``str``
         """
-        temp_dir_path = tempfile.mkdtemp()
+        temp_dir_path = tempfile.mkdtemp(dir=self.tmp_dir_prefix)
+        if not self.tmp_dir_prefix:
+            # set self.tmp_dir_prefix to the path selected by mkdtemp, it's used elsewhere for
+            # asserts.
+            self.tmp_dir_prefix, tmp_file = os.path.split(temp_dir_path)
+        LOG.info('Using temp dir prefix: %s', temp_dir_path)
 
         for directory_name in DIRECTORY_STRUCTURE:
             full_path = os.path.join(temp_dir_path, directory_name)

--- a/st2debug/st2debug/processors.py
+++ b/st2debug/st2debug/processors.py
@@ -43,7 +43,7 @@ def process_st2_config(config_path, tmp_prefix):
     """
     Remove sensitive data (credentials) from the StackStorm config.
 
-    :param config_path: Full absolute path to the st2 config inside TMP_DIR.
+    :param config_path: Full absolute path to the st2 config inside temporary directory.
     :type config_path: ``str``
     :param tmp_prefix: Base path where temporary files are placed.
     :type tmp_prefix: ``str``
@@ -69,7 +69,7 @@ def process_mistral_config(config_path, tmp_prefix):
     """
     Remove sensitive data (credentials) from the Mistral config.
 
-    :param config_path: Full absolute path to the mistral config inside TMP_DIR.
+    :param config_path: Full absolute path to the mistral config inside temporary directory.
     :type config_path: ``str``
     :param tmp_prefix: Base path where temporary files are placed.
     :type tmp_prefix: ``str``
@@ -95,7 +95,7 @@ def process_content_pack_dir(pack_dir, tmp_prefix):
     """
     Remove config.yaml from the pack directory.
 
-    :param pack_dir: Full absolute path to the pack directory inside TMP_DIR.
+    :param pack_dir: Full absolute path to the pack directory inside temporary directory.
     :type pack_dir: ``str``
     :param tmp_prefix: Base path where temporary files are placed.
     :type tmp_prefix: ``str``

--- a/st2debug/st2debug/processors.py
+++ b/st2debug/st2debug/processors.py
@@ -38,14 +38,17 @@ MISTRAL_CONF_OPTIONS_TO_REMOVE = {
 REMOVED_VALUE_NAME = '**removed**'
 
 
-def process_st2_config(config_path):
+
+def process_st2_config(config_path, tmp_prefix):
     """
     Remove sensitive data (credentials) from the StackStorm config.
 
-    :param config_path: Full absolute path to the st2 config inside /tmp.
+    :param config_path: Full absolute path to the st2 config inside TMP_DIR.
     :type config_path: ``str``
+    :param tmp_prefix: Base path where temporary files are placed.
+    :type tmp_prefix: ``str``
     """
-    assert config_path.startswith('/tmp')
+    assert config_path.startswith(tmp_prefix)
 
     if not os.path.isfile(config_path):
         return
@@ -62,14 +65,16 @@ def process_st2_config(config_path):
         config.write(fp)
 
 
-def process_mistral_config(config_path):
+def process_mistral_config(config_path, tmp_prefix):
     """
     Remove sensitive data (credentials) from the Mistral config.
 
-    :param config_path: Full absolute path to the mistral config inside /tmp.
+    :param config_path: Full absolute path to the mistral config inside TMP_DIR.
     :type config_path: ``str``
+    :param tmp_prefix: Base path where temporary files are placed.
+    :type tmp_prefix: ``str``
     """
-    assert config_path.startswith('/tmp')
+    assert config_path.startswith(tmp_prefix)
 
     if not os.path.isfile(config_path):
         return
@@ -86,14 +91,16 @@ def process_mistral_config(config_path):
         config.write(fp)
 
 
-def process_content_pack_dir(pack_dir):
+def process_content_pack_dir(pack_dir, tmp_prefix):
     """
     Remove config.yaml from the pack directory.
 
-    :param pack_dir: Full absolute path to the pack directory inside /tmp.
+    :param pack_dir: Full absolute path to the pack directory inside TMP_DIR.
     :type pack_dir: ``str``
+    :param tmp_prefix: Base path where temporary files are placed.
+    :type tmp_prefix: ``str``
     """
-    assert pack_dir.startswith('/tmp')
+    assert pack_dir.startswith(tmp_prefix)
 
     config_file_path = os.path.join(pack_dir, 'config.yaml')
     if os.path.isfile(config_file_path):


### PR DESCRIPTION

Add `st2_debug_tmp_path` value to the submit-debug-info.yaml config file which allows one to over-ride the default temporary file location which used to be '/tmp'. Also, depending on the underlying os, the `tempfile.mkdtemp` method was not guaranteed to use '/tmp', yet some of the asserts were making that assumption.