### PR TITLE
apply workarounds for pip 10 internal API changes from upstream

### DIFF
--- a/scripts/dist_utils.py
+++ b/scripts/dist_utils.py
@@ -14,14 +14,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
+import re
+import sys
 
-from pip.req import parse_requirements
+from distutils.version import StrictVersion
+
+GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
+
+try:
+    import pip
+    from pip import __version__ as pip_version
+except ImportError as e:
+    print('Failed to import pip: %s' % (str(e)))
+    print('')
+    print('Download pip:\n%s' % (GET_PIP))
+    sys.exit(1)
+
+try:
+    # pip < 10.0
+    from pip.req import parse_requirements
+except ImportError:
+    # pip >= 10.0
+
+    try:
+        from pip._internal.req.req_file import parse_requirements
+    except ImportError as e:
+        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Using pip: %s' % (str(pip_version)))
+        sys.exit(1)
 
 __all__ = [
+    'check_pip_version',
     'fetch_requirements',
-    'apply_vagrant_workaround'
+    'apply_vagrant_workaround',
+    'get_version_string',
+    'parse_version_string'
 ]
+
+
+def check_pip_version():
+    """
+    Ensure that a minimum supported version of pip is installed.
+    """
+    if StrictVersion(pip.__version__) < StrictVersion('6.0.0'):
+        print("Upgrade pip, your version `{0}' "
+              "is outdated:\n{1}".format(pip.__version__, GET_PIP))
+        sys.exit(1)
 
 
 def fetch_requirements(requirements_file_path):
@@ -46,3 +86,22 @@ def apply_vagrant_workaround():
     """
     if os.environ.get('USER', None) == 'vagrant':
         del os.link
+
+
+def get_version_string(init_file):
+    """
+    Read __version__ string for an init file.
+    """
+
+    with open(init_file, 'r') as fp:
+        content = fp.read()
+        version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                                  content, re.M)
+        if version_match:
+            return version_match.group(1)
+
+        raise RuntimeError('Unable to find version string in %s.' % (init_file))
+
+
+# alias for get_version_string
+parse_version_string = get_version_string

--- a/st2actions/dist_utils.py
+++ b/st2actions/dist_utils.py
@@ -14,14 +14,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
+import re
+import sys
 
-from pip.req import parse_requirements
+from distutils.version import StrictVersion
+
+GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
+
+try:
+    import pip
+    from pip import __version__ as pip_version
+except ImportError as e:
+    print('Failed to import pip: %s' % (str(e)))
+    print('')
+    print('Download pip:\n%s' % (GET_PIP))
+    sys.exit(1)
+
+try:
+    # pip < 10.0
+    from pip.req import parse_requirements
+except ImportError:
+    # pip >= 10.0
+
+    try:
+        from pip._internal.req.req_file import parse_requirements
+    except ImportError as e:
+        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Using pip: %s' % (str(pip_version)))
+        sys.exit(1)
 
 __all__ = [
+    'check_pip_version',
     'fetch_requirements',
-    'apply_vagrant_workaround'
+    'apply_vagrant_workaround',
+    'get_version_string',
+    'parse_version_string'
 ]
+
+
+def check_pip_version():
+    """
+    Ensure that a minimum supported version of pip is installed.
+    """
+    if StrictVersion(pip.__version__) < StrictVersion('6.0.0'):
+        print("Upgrade pip, your version `{0}' "
+              "is outdated:\n{1}".format(pip.__version__, GET_PIP))
+        sys.exit(1)
 
 
 def fetch_requirements(requirements_file_path):
@@ -46,3 +86,22 @@ def apply_vagrant_workaround():
     """
     if os.environ.get('USER', None) == 'vagrant':
         del os.link
+
+
+def get_version_string(init_file):
+    """
+    Read __version__ string for an init file.
+    """
+
+    with open(init_file, 'r') as fp:
+        content = fp.read()
+        version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                                  content, re.M)
+        if version_match:
+            return version_match.group(1)
+
+        raise RuntimeError('Unable to find version string in %s.' % (init_file))
+
+
+# alias for get_version_string
+parse_version_string = get_version_string

--- a/st2api/dist_utils.py
+++ b/st2api/dist_utils.py
@@ -14,14 +14,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
+import re
+import sys
 
-from pip.req import parse_requirements
+from distutils.version import StrictVersion
+
+GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
+
+try:
+    import pip
+    from pip import __version__ as pip_version
+except ImportError as e:
+    print('Failed to import pip: %s' % (str(e)))
+    print('')
+    print('Download pip:\n%s' % (GET_PIP))
+    sys.exit(1)
+
+try:
+    # pip < 10.0
+    from pip.req import parse_requirements
+except ImportError:
+    # pip >= 10.0
+
+    try:
+        from pip._internal.req.req_file import parse_requirements
+    except ImportError as e:
+        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Using pip: %s' % (str(pip_version)))
+        sys.exit(1)
 
 __all__ = [
+    'check_pip_version',
     'fetch_requirements',
-    'apply_vagrant_workaround'
+    'apply_vagrant_workaround',
+    'get_version_string',
+    'parse_version_string'
 ]
+
+
+def check_pip_version():
+    """
+    Ensure that a minimum supported version of pip is installed.
+    """
+    if StrictVersion(pip.__version__) < StrictVersion('6.0.0'):
+        print("Upgrade pip, your version `{0}' "
+              "is outdated:\n{1}".format(pip.__version__, GET_PIP))
+        sys.exit(1)
 
 
 def fetch_requirements(requirements_file_path):
@@ -46,3 +86,22 @@ def apply_vagrant_workaround():
     """
     if os.environ.get('USER', None) == 'vagrant':
         del os.link
+
+
+def get_version_string(init_file):
+    """
+    Read __version__ string for an init file.
+    """
+
+    with open(init_file, 'r') as fp:
+        content = fp.read()
+        version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                                  content, re.M)
+        if version_match:
+            return version_match.group(1)
+
+        raise RuntimeError('Unable to find version string in %s.' % (init_file))
+
+
+# alias for get_version_string
+parse_version_string = get_version_string

--- a/st2auth/dist_utils.py
+++ b/st2auth/dist_utils.py
@@ -14,14 +14,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
+import re
+import sys
 
-from pip.req import parse_requirements
+from distutils.version import StrictVersion
+
+GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
+
+try:
+    import pip
+    from pip import __version__ as pip_version
+except ImportError as e:
+    print('Failed to import pip: %s' % (str(e)))
+    print('')
+    print('Download pip:\n%s' % (GET_PIP))
+    sys.exit(1)
+
+try:
+    # pip < 10.0
+    from pip.req import parse_requirements
+except ImportError:
+    # pip >= 10.0
+
+    try:
+        from pip._internal.req.req_file import parse_requirements
+    except ImportError as e:
+        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Using pip: %s' % (str(pip_version)))
+        sys.exit(1)
 
 __all__ = [
+    'check_pip_version',
     'fetch_requirements',
-    'apply_vagrant_workaround'
+    'apply_vagrant_workaround',
+    'get_version_string',
+    'parse_version_string'
 ]
+
+
+def check_pip_version():
+    """
+    Ensure that a minimum supported version of pip is installed.
+    """
+    if StrictVersion(pip.__version__) < StrictVersion('6.0.0'):
+        print("Upgrade pip, your version `{0}' "
+              "is outdated:\n{1}".format(pip.__version__, GET_PIP))
+        sys.exit(1)
 
 
 def fetch_requirements(requirements_file_path):
@@ -46,3 +86,22 @@ def apply_vagrant_workaround():
     """
     if os.environ.get('USER', None) == 'vagrant':
         del os.link
+
+
+def get_version_string(init_file):
+    """
+    Read __version__ string for an init file.
+    """
+
+    with open(init_file, 'r') as fp:
+        content = fp.read()
+        version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                                  content, re.M)
+        if version_match:
+            return version_match.group(1)
+
+        raise RuntimeError('Unable to find version string in %s.' % (init_file))
+
+
+# alias for get_version_string
+parse_version_string = get_version_string

--- a/st2client/dist_utils.py
+++ b/st2client/dist_utils.py
@@ -14,14 +14,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
+import re
+import sys
 
-from pip.req import parse_requirements
+from distutils.version import StrictVersion
+
+GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
+
+try:
+    import pip
+    from pip import __version__ as pip_version
+except ImportError as e:
+    print('Failed to import pip: %s' % (str(e)))
+    print('')
+    print('Download pip:\n%s' % (GET_PIP))
+    sys.exit(1)
+
+try:
+    # pip < 10.0
+    from pip.req import parse_requirements
+except ImportError:
+    # pip >= 10.0
+
+    try:
+        from pip._internal.req.req_file import parse_requirements
+    except ImportError as e:
+        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Using pip: %s' % (str(pip_version)))
+        sys.exit(1)
 
 __all__ = [
+    'check_pip_version',
     'fetch_requirements',
-    'apply_vagrant_workaround'
+    'apply_vagrant_workaround',
+    'get_version_string',
+    'parse_version_string'
 ]
+
+
+def check_pip_version():
+    """
+    Ensure that a minimum supported version of pip is installed.
+    """
+    if StrictVersion(pip.__version__) < StrictVersion('6.0.0'):
+        print("Upgrade pip, your version `{0}' "
+              "is outdated:\n{1}".format(pip.__version__, GET_PIP))
+        sys.exit(1)
 
 
 def fetch_requirements(requirements_file_path):
@@ -46,3 +86,22 @@ def apply_vagrant_workaround():
     """
     if os.environ.get('USER', None) == 'vagrant':
         del os.link
+
+
+def get_version_string(init_file):
+    """
+    Read __version__ string for an init file.
+    """
+
+    with open(init_file, 'r') as fp:
+        content = fp.read()
+        version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                                  content, re.M)
+        if version_match:
+            return version_match.group(1)
+
+        raise RuntimeError('Unable to find version string in %s.' % (init_file))
+
+
+# alias for get_version_string
+parse_version_string = get_version_string

--- a/st2common/dist_utils.py
+++ b/st2common/dist_utils.py
@@ -14,14 +14,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
+import re
+import sys
 
-from pip.req import parse_requirements
+from distutils.version import StrictVersion
+
+GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
+
+try:
+    import pip
+    from pip import __version__ as pip_version
+except ImportError as e:
+    print('Failed to import pip: %s' % (str(e)))
+    print('')
+    print('Download pip:\n%s' % (GET_PIP))
+    sys.exit(1)
+
+try:
+    # pip < 10.0
+    from pip.req import parse_requirements
+except ImportError:
+    # pip >= 10.0
+
+    try:
+        from pip._internal.req.req_file import parse_requirements
+    except ImportError as e:
+        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Using pip: %s' % (str(pip_version)))
+        sys.exit(1)
 
 __all__ = [
+    'check_pip_version',
     'fetch_requirements',
-    'apply_vagrant_workaround'
+    'apply_vagrant_workaround',
+    'get_version_string',
+    'parse_version_string'
 ]
+
+
+def check_pip_version():
+    """
+    Ensure that a minimum supported version of pip is installed.
+    """
+    if StrictVersion(pip.__version__) < StrictVersion('6.0.0'):
+        print("Upgrade pip, your version `{0}' "
+              "is outdated:\n{1}".format(pip.__version__, GET_PIP))
+        sys.exit(1)
 
 
 def fetch_requirements(requirements_file_path):
@@ -46,3 +86,22 @@ def apply_vagrant_workaround():
     """
     if os.environ.get('USER', None) == 'vagrant':
         del os.link
+
+
+def get_version_string(init_file):
+    """
+    Read __version__ string for an init file.
+    """
+
+    with open(init_file, 'r') as fp:
+        content = fp.read()
+        version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                                  content, re.M)
+        if version_match:
+            return version_match.group(1)
+
+        raise RuntimeError('Unable to find version string in %s.' % (init_file))
+
+
+# alias for get_version_string
+parse_version_string = get_version_string

--- a/st2debug/dist_utils.py
+++ b/st2debug/dist_utils.py
@@ -14,14 +14,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
+import re
+import sys
 
-from pip.req import parse_requirements
+from distutils.version import StrictVersion
+
+GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
+
+try:
+    import pip
+    from pip import __version__ as pip_version
+except ImportError as e:
+    print('Failed to import pip: %s' % (str(e)))
+    print('')
+    print('Download pip:\n%s' % (GET_PIP))
+    sys.exit(1)
+
+try:
+    # pip < 10.0
+    from pip.req import parse_requirements
+except ImportError:
+    # pip >= 10.0
+
+    try:
+        from pip._internal.req.req_file import parse_requirements
+    except ImportError as e:
+        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Using pip: %s' % (str(pip_version)))
+        sys.exit(1)
 
 __all__ = [
+    'check_pip_version',
     'fetch_requirements',
-    'apply_vagrant_workaround'
+    'apply_vagrant_workaround',
+    'get_version_string',
+    'parse_version_string'
 ]
+
+
+def check_pip_version():
+    """
+    Ensure that a minimum supported version of pip is installed.
+    """
+    if StrictVersion(pip.__version__) < StrictVersion('6.0.0'):
+        print("Upgrade pip, your version `{0}' "
+              "is outdated:\n{1}".format(pip.__version__, GET_PIP))
+        sys.exit(1)
 
 
 def fetch_requirements(requirements_file_path):
@@ -46,3 +86,22 @@ def apply_vagrant_workaround():
     """
     if os.environ.get('USER', None) == 'vagrant':
         del os.link
+
+
+def get_version_string(init_file):
+    """
+    Read __version__ string for an init file.
+    """
+
+    with open(init_file, 'r') as fp:
+        content = fp.read()
+        version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                                  content, re.M)
+        if version_match:
+            return version_match.group(1)
+
+        raise RuntimeError('Unable to find version string in %s.' % (init_file))
+
+
+# alias for get_version_string
+parse_version_string = get_version_string

--- a/st2exporter/dist_utils.py
+++ b/st2exporter/dist_utils.py
@@ -14,14 +14,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
+import re
+import sys
 
-from pip.req import parse_requirements
+from distutils.version import StrictVersion
+
+GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
+
+try:
+    import pip
+    from pip import __version__ as pip_version
+except ImportError as e:
+    print('Failed to import pip: %s' % (str(e)))
+    print('')
+    print('Download pip:\n%s' % (GET_PIP))
+    sys.exit(1)
+
+try:
+    # pip < 10.0
+    from pip.req import parse_requirements
+except ImportError:
+    # pip >= 10.0
+
+    try:
+        from pip._internal.req.req_file import parse_requirements
+    except ImportError as e:
+        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Using pip: %s' % (str(pip_version)))
+        sys.exit(1)
 
 __all__ = [
+    'check_pip_version',
     'fetch_requirements',
-    'apply_vagrant_workaround'
+    'apply_vagrant_workaround',
+    'get_version_string',
+    'parse_version_string'
 ]
+
+
+def check_pip_version():
+    """
+    Ensure that a minimum supported version of pip is installed.
+    """
+    if StrictVersion(pip.__version__) < StrictVersion('6.0.0'):
+        print("Upgrade pip, your version `{0}' "
+              "is outdated:\n{1}".format(pip.__version__, GET_PIP))
+        sys.exit(1)
 
 
 def fetch_requirements(requirements_file_path):
@@ -46,3 +86,22 @@ def apply_vagrant_workaround():
     """
     if os.environ.get('USER', None) == 'vagrant':
         del os.link
+
+
+def get_version_string(init_file):
+    """
+    Read __version__ string for an init file.
+    """
+
+    with open(init_file, 'r') as fp:
+        content = fp.read()
+        version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                                  content, re.M)
+        if version_match:
+            return version_match.group(1)
+
+        raise RuntimeError('Unable to find version string in %s.' % (init_file))
+
+
+# alias for get_version_string
+parse_version_string = get_version_string

--- a/st2reactor/dist_utils.py
+++ b/st2reactor/dist_utils.py
@@ -14,14 +14,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
+import re
+import sys
 
-from pip.req import parse_requirements
+from distutils.version import StrictVersion
+
+GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
+
+try:
+    import pip
+    from pip import __version__ as pip_version
+except ImportError as e:
+    print('Failed to import pip: %s' % (str(e)))
+    print('')
+    print('Download pip:\n%s' % (GET_PIP))
+    sys.exit(1)
+
+try:
+    # pip < 10.0
+    from pip.req import parse_requirements
+except ImportError:
+    # pip >= 10.0
+
+    try:
+        from pip._internal.req.req_file import parse_requirements
+    except ImportError as e:
+        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Using pip: %s' % (str(pip_version)))
+        sys.exit(1)
 
 __all__ = [
+    'check_pip_version',
     'fetch_requirements',
-    'apply_vagrant_workaround'
+    'apply_vagrant_workaround',
+    'get_version_string',
+    'parse_version_string'
 ]
+
+
+def check_pip_version():
+    """
+    Ensure that a minimum supported version of pip is installed.
+    """
+    if StrictVersion(pip.__version__) < StrictVersion('6.0.0'):
+        print("Upgrade pip, your version `{0}' "
+              "is outdated:\n{1}".format(pip.__version__, GET_PIP))
+        sys.exit(1)
 
 
 def fetch_requirements(requirements_file_path):
@@ -46,3 +86,22 @@ def apply_vagrant_workaround():
     """
     if os.environ.get('USER', None) == 'vagrant':
         del os.link
+
+
+def get_version_string(init_file):
+    """
+    Read __version__ string for an init file.
+    """
+
+    with open(init_file, 'r') as fp:
+        content = fp.read()
+        version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                                  content, re.M)
+        if version_match:
+            return version_match.group(1)
+
+        raise RuntimeError('Unable to find version string in %s.' % (init_file))
+
+
+# alias for get_version_string
+parse_version_string = get_version_string

--- a/st2stream/dist_utils.py
+++ b/st2stream/dist_utils.py
@@ -14,14 +14,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
+import re
+import sys
 
-from pip.req import parse_requirements
+from distutils.version import StrictVersion
+
+GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
+
+try:
+    import pip
+    from pip import __version__ as pip_version
+except ImportError as e:
+    print('Failed to import pip: %s' % (str(e)))
+    print('')
+    print('Download pip:\n%s' % (GET_PIP))
+    sys.exit(1)
+
+try:
+    # pip < 10.0
+    from pip.req import parse_requirements
+except ImportError:
+    # pip >= 10.0
+
+    try:
+        from pip._internal.req.req_file import parse_requirements
+    except ImportError as e:
+        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Using pip: %s' % (str(pip_version)))
+        sys.exit(1)
 
 __all__ = [
+    'check_pip_version',
     'fetch_requirements',
-    'apply_vagrant_workaround'
+    'apply_vagrant_workaround',
+    'get_version_string',
+    'parse_version_string'
 ]
+
+
+def check_pip_version():
+    """
+    Ensure that a minimum supported version of pip is installed.
+    """
+    if StrictVersion(pip.__version__) < StrictVersion('6.0.0'):
+        print("Upgrade pip, your version `{0}' "
+              "is outdated:\n{1}".format(pip.__version__, GET_PIP))
+        sys.exit(1)
 
 
 def fetch_requirements(requirements_file_path):
@@ -46,3 +86,22 @@ def apply_vagrant_workaround():
     """
     if os.environ.get('USER', None) == 'vagrant':
         del os.link
+
+
+def get_version_string(init_file):
+    """
+    Read __version__ string for an init file.
+    """
+
+    with open(init_file, 'r') as fp:
+        content = fp.read()
+        version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                                  content, re.M)
+        if version_match:
+            return version_match.group(1)
+
+        raise RuntimeError('Unable to find version string in %s.' % (init_file))
+
+
+# alias for get_version_string
+parse_version_string = get_version_string

--- a/st2tests/dist_utils.py
+++ b/st2tests/dist_utils.py
@@ -14,14 +14,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
+import re
+import sys
 
-from pip.req import parse_requirements
+from distutils.version import StrictVersion
+
+GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
+
+try:
+    import pip
+    from pip import __version__ as pip_version
+except ImportError as e:
+    print('Failed to import pip: %s' % (str(e)))
+    print('')
+    print('Download pip:\n%s' % (GET_PIP))
+    sys.exit(1)
+
+try:
+    # pip < 10.0
+    from pip.req import parse_requirements
+except ImportError:
+    # pip >= 10.0
+
+    try:
+        from pip._internal.req.req_file import parse_requirements
+    except ImportError as e:
+        print('Failed to import parse_requirements from pip: %s' % (str(e)))
+        print('Using pip: %s' % (str(pip_version)))
+        sys.exit(1)
 
 __all__ = [
+    'check_pip_version',
     'fetch_requirements',
-    'apply_vagrant_workaround'
+    'apply_vagrant_workaround',
+    'get_version_string',
+    'parse_version_string'
 ]
+
+
+def check_pip_version():
+    """
+    Ensure that a minimum supported version of pip is installed.
+    """
+    if StrictVersion(pip.__version__) < StrictVersion('6.0.0'):
+        print("Upgrade pip, your version `{0}' "
+              "is outdated:\n{1}".format(pip.__version__, GET_PIP))
+        sys.exit(1)
 
 
 def fetch_requirements(requirements_file_path):
@@ -46,3 +86,22 @@ def apply_vagrant_workaround():
     """
     if os.environ.get('USER', None) == 'vagrant':
         del os.link
+
+
+def get_version_string(init_file):
+    """
+    Read __version__ string for an init file.
+    """
+
+    with open(init_file, 'r') as fp:
+        content = fp.read()
+        version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                                  content, re.M)
+        if version_match:
+            return version_match.group(1)
+
+        raise RuntimeError('Unable to find version string in %s.' % (init_file))
+
+
+# alias for get_version_string
+parse_version_string = get_version_string


### PR DESCRIPTION
TL; DR: syncing the `dist_utils.py` file for each `st2-*` python package in the st2 repo so that plexxi stackstorm v2.2.1 will build using pip 10.