### PR TITLE
fix stderr log formatter to contain timestamp and level

### DIFF
--- a/st2common/st2common/runners/utils.py
+++ b/st2common/st2common/runners/utils.py
@@ -97,7 +97,7 @@ def get_logger_for_python_runner_action(action_name, log_level='debug'):
         console = stdlib_logging.StreamHandler()
         console.setLevel(log_level_constant)
 
-        formatter = stdlib_logging.Formatter('%(name)-12s: %(levelname)-8s %(message)s')
+        formatter = stdlib_logging.Formatter('%(asctime)s: %(levelname)-8s %(message)s')
         console.setFormatter(formatter)
         logger.addHandler(console)
         logger.setLevel(log_level_constant)


### PR DESCRIPTION
the function name is useless
we just need the log level and time